### PR TITLE
Add socket.io ack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ See `example/lib/main.dart` for better example
 ```
 
 To request callback on ack:
-```  socket.emitWithAck("message", ["Hello world!"]).then( (data) {
-     // callback when this message is acknowledged by the server
-     print(data);
-   });
+```dart
+  socket.emitWithAck("message", ["Hello world!"]).then( (data) {
+    // this callback runs when this specific message is acknowledged by the server
+    print(data);
+  });
 ```
 
 ## Running example:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ See `example/lib/main.dart` for better example
 
 ```
 
+To request callback on ack:
+```  socket.emitWithAck("message", ["Hello world!"]).then( (data) {
+     // callback when this message is acknowledged by the server
+     print(data);
+   });
+```
+
 ## Running example:
 
 

--- a/android/src/main/java/com/infitio/adharasocketio/AdharaSocket.java
+++ b/android/src/main/java/com/infitio/adharasocketio/AdharaSocket.java
@@ -130,7 +130,30 @@ class AdharaSocket implements MethodCallHandler {
                         }
                     }
                 }
-                socket.emit(eventName, array);
+                if (reqId == null) {
+                    socket.emit(eventName, array);
+                } else {
+                    socket.emit(eventName, array, new Ack() {
+
+                        @Override
+                        public void call(Object... args) {
+                            log("Ack received:::"+eventName);
+                            Map<String, Object> arguments = new HashMap<>();
+                            arguments.put("reqId", reqId);
+                            List<String> argsList = new ArrayList<>();
+                            for(Object arg : args){
+                                if((arg instanceof JSONObject)
+                                        || (arg instanceof JSONArray)){
+                                    argsList.add(arg.toString());
+                                }else if(arg!=null){
+                                    argsList.add(arg.toString());
+                                }
+                            }
+                            arguments.put("args", argsList);
+                            channel.invokeMethod("incomingAck", arguments);
+                        }
+                    });
+                }
                 result.success(null);
                 break;
             }

--- a/android/src/main/java/com/infitio/adharasocketio/AdharaSocket.java
+++ b/android/src/main/java/com/infitio/adharasocketio/AdharaSocket.java
@@ -104,6 +104,7 @@ class AdharaSocket implements MethodCallHandler {
             case "emit": {
                 final String eventName = call.argument("eventName");
                 final List data = call.argument("arguments");
+                final String reqId = call.argument("reqId");
                 log("emitting:::"+data+":::to:::"+eventName);
                 Object[] array = {};
                 if(data!=null){

--- a/ios/Classes/AdharaSocket.swift
+++ b/ios/Classes/AdharaSocket.swift
@@ -71,8 +71,18 @@ public class AdharaSocket: NSObject, FlutterPlugin {
             case "emit":
                 let eventName: String = arguments["eventName"] as! String
                 let data: [Any] = arguments["arguments"] as! [Any]
+                let reqId: String = arguments["reqId"] as! String
                 self.log("emitting:::", data, ":::to:::", eventName);
-                socket.emit(eventName, with: data)
+                if (reqId == nil) {
+                    socket.emit(eventName, with: data)
+                } else {
+                    socket.emitWithAck(eventName, with: data).timingOut(after: 0) { data in 
+                        self.channel.invokeMethod("incomingAck", arguments: [
+                            "args": data,
+                            "reqId": reqId
+                        ]);
+                    }
+                }
                 result(nil)
             case "isConnected":
                 self.log("connected")


### PR DESCRIPTION
Add callback support upon server ack after emit:

    socket.emitWithAck("message", ["Hello world!"]).then( (data) {
      // this callback runs when this specific message is acknowledged by the server
      print(data);
    });
    
    When ACK is requested, a Future is returned, which will be completed once the
    server acknowledges the request. Note that there is no guarantee that the server
    will ever acknowledge the request, and the current implementation does not provide
    any timeout or garbage collection mechanism.
