### PR TITLE
Fix multiple listen to same event

### DIFF
--- a/lib/socket.dart
+++ b/lib/socket.dart
@@ -73,9 +73,9 @@ class SocketIO {
   on(String eventName, SocketEventListener listener) async {
     if (_listeners[eventName] == null) {
       _listeners[eventName] = [];
+      _channel.invokeMethod("on", {"eventName": eventName});
     }
     _listeners[eventName].add(listener);
-    await _channel.invokeMethod("on", {"eventName": eventName});
   }
 
   ///stop listening to an event.


### PR DESCRIPTION
When we listened n times to the same event, each listener was called n times because it subscribed to the platform event each time.