### PR TITLE
Fixes the specify a swift version error on pod install

### DIFF
--- a/ios/adhara_socket_io.podspec
+++ b/ios/adhara_socket_io.podspec
@@ -18,6 +18,7 @@ socket.io for flutter by adhara
   s.dependency 'Socket.IO-Client-Swift'
   s.dependency 'Starscream'
 
+  s.swift_version = '4.2'
   s.ios.deployment_target = '9.0'
 end
 


### PR DESCRIPTION
- `adhara_socket_io` does not specify a Swift version and none of the targets (`Runner`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.


this will fix it