### PR TITLE
Expose method `isConnected` on socket interface

### DIFF
--- a/lib/socket.dart
+++ b/lib/socket.dart
@@ -143,6 +143,10 @@ class SocketIO {
     return completer.future;
   }
 
+  Future<bool> isConnected() async {
+    return await _channel.invokeMethod('isConnected');
+  }
+
   ///Data listener called by platform API
   _handleData(String eventName, List arguments) {
     _listeners[eventName]?.forEach((Function listener) {


### PR DESCRIPTION
This PR just expose method `isConnected`, that was already implemented on both platforms via method channel.

Fixes #90 