### PR TITLE
Socket.IO Reconnecting issue fixed with downgrading version Java Sock…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation ('io.socket:socket.io-client:1.0.0') {
+    implementation ('io.socket:socket.io-client:0.8.3') {
         // excluding org.json which is provided by Android
         exclude group: 'org.json', module: 'json'
     }


### PR DESCRIPTION
Java Socket.IO library v1.0.0 is not working in Android, the connection is always reconnecting. This issue was not in v0.8.3 socket client. This library is downgraded from this plugin. It works fine now.

This dependency can be upgraded when this bug is fixed from Java Socket.IO client-side. 